### PR TITLE
feat(cms): Add Orders Payload collection to CMS

### DIFF
--- a/apps/cms/docker/development/docker-compose.yml
+++ b/apps/cms/docker/development/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     command:
       - --storageEngine=wiredTiger
     volumes:
-      - ./data:/data/db
+      - data:/data/db
 
 volumes:
   data:

--- a/apps/cms/src/collections/Media.ts
+++ b/apps/cms/src/collections/Media.ts
@@ -1,4 +1,5 @@
 import { CollectionConfig } from "payload/types";
+import { isUsingCloudStore } from "../utilities/cloud";
 
 const Media: CollectionConfig = {
   slug: "media",
@@ -18,7 +19,9 @@ const Media: CollectionConfig = {
     staticURL: "/media",
     staticDir: "media",
     mimeTypes: ["image/*"],
-    disableLocalStorage: true,
+    // disable local storage of media assets if using cloud storage
+    // otherwise allow local storage for local development
+    disableLocalStorage: isUsingCloudStore(),
   },
 };
 export default Media;

--- a/apps/cms/src/collections/Orders.ts
+++ b/apps/cms/src/collections/Orders.ts
@@ -27,15 +27,15 @@ const Orders: CollectionConfig = {
       type: "select",
       options: [
         {
-          value: "1",
+          value: "pending",
           label: "Pending Payment",
         },
         {
-          value: "2",
+          value: "paid",
           label: "Payment Completed",
         },
         {
-          value: "3",
+          value: "delivered",
           label: "Order Completed",
         },
       ],

--- a/apps/cms/src/collections/Orders.ts
+++ b/apps/cms/src/collections/Orders.ts
@@ -1,0 +1,65 @@
+import { CollectionConfig } from "payload/types";
+
+/** Orders collection stores merch orders from users. */
+const Orders: CollectionConfig = {
+  slug: "orders",
+  admin: {
+    defaultColumns: ["id", "orderDateTime", "status", "updatedAt"],
+    description: "Merchandise orders from users.",
+  },
+  fields: [
+    // by default, payload generates an 'id' field each order automatically
+    {
+      name: "paymentGateway",
+      type: "text",
+      required: true,
+    },
+    // TODO(mrzzy): orderItems
+    {
+      name: "status",
+      label: "Order Status",
+      type: "select",
+      options: [
+        {
+          value: "1",
+          label: "Pending Payment",
+        },
+        {
+          value: "2",
+          label: "Payment Completed",
+        },
+        {
+          value: "3",
+          label: "Order Completed",
+        },
+      ],
+      required: true,
+    },
+    {
+      name: "customerEmail",
+      type: "email",
+      required: true,
+    },
+    {
+      name: "transactionID",
+      label: "Transaction ID",
+      admin: {
+        description: "Transaction ID provided by Payment Gateway",
+      },
+      type: "text",
+      required: true,
+    },
+    {
+      name: "orderDateTime",
+      label: "Ordered On",
+      type: "date",
+      admin: {
+        date: {
+          pickerAppearance: "dayAndTime",
+        },
+      },
+      required: true,
+    },
+  ],
+};
+export default Orders;

--- a/apps/cms/src/collections/Orders.ts
+++ b/apps/cms/src/collections/Orders.ts
@@ -1,10 +1,17 @@
 import { CollectionConfig } from "payload/types";
+import Media from "./Media";
 
 /** Orders collection stores merch orders from users. */
 const Orders: CollectionConfig = {
   slug: "orders",
   admin: {
-    defaultColumns: ["id", "orderDateTime", "status", "updatedAt"],
+    defaultColumns: [
+      "id",
+      "orderItems",
+      "orderDateTime",
+      "status",
+      "updatedAt",
+    ],
     description: "Merchandise orders from users.",
   },
   fields: [
@@ -14,7 +21,6 @@ const Orders: CollectionConfig = {
       type: "text",
       required: true,
     },
-    // TODO(mrzzy): orderItems
     {
       name: "status",
       label: "Order Status",
@@ -59,6 +65,51 @@ const Orders: CollectionConfig = {
         },
       },
       required: true,
+    },
+    // ordered items for this order
+    {
+      name: "orderItems",
+      type: "array",
+      fields: [
+        {
+          name: "image",
+          type: "upload",
+          relationTo: Media.slug,
+          // validation: only allow image filetypes
+          filterOptions: {
+            mimeType: { contains: "image" },
+          },
+        },
+        {
+          name: "quantity",
+          type: "number",
+          required: true,
+        },
+        {
+          name: "size",
+          type: "text",
+          required: true,
+        },
+        {
+          name: "price",
+          type: "number",
+          required: true,
+        },
+        {
+          name: "name",
+          type: "text",
+          required: true,
+        },
+        {
+          name: "colorway",
+          type: "text",
+          required: true,
+        },
+      ],
+      // direct paylaod to generate a OrderItem type
+      interfaceName: "OrderItem",
+      // validate: orders should not be empty
+      minRows: 1,
     },
   ],
 };

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -16,6 +16,7 @@ import MerchOverview from "./admin/views/MerchOverview";
 import MerchProducts from "./admin/views/MerchProducts";
 import { SCSEIcon, SCSELogo } from "./admin/graphics/Logos";
 import BeforeNavLinks from "./admin/components/BeforeNavLinks";
+import Order from './collections/Orders';
 
 const adapter = createS3Adapter({
   config: {
@@ -62,6 +63,7 @@ export default buildConfig({
     Tags,
     Users,
     Media,
+    Order,
   ],
   csrf: [
     // whitelist of domains to allow cookie auth from

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -1,12 +1,12 @@
-import { buildConfig } from 'payload/config';
-import { cloudStorage } from '@payloadcms/plugin-cloud-storage';
-import { s3Adapter as createS3Adapter } from '@payloadcms/plugin-cloud-storage/s3';
-import path from 'path';
+import { buildConfig } from "payload/config";
+import { cloudStorage } from "@payloadcms/plugin-cloud-storage";
+import { s3Adapter as createS3Adapter } from "@payloadcms/plugin-cloud-storage/s3";
+import path from "path";
 
-import Categories from './collections/Categories';
-import Posts from './collections/Posts';
-import Tags from './collections/Tags';
-import Users from './collections/Users';
+import Categories from "./collections/Categories";
+import Posts from "./collections/Posts";
+import Tags from "./collections/Tags";
+import Users from "./collections/Users";
 import Media from "./collections/Media";
 
 import AfterNavLinks from "./admin/components/AfterNavLinks";
@@ -16,9 +16,8 @@ import MerchOverview from "./admin/views/MerchOverview";
 import MerchProducts from "./admin/views/MerchProducts";
 import { SCSEIcon, SCSELogo } from "./admin/graphics/Logos";
 import BeforeNavLinks from "./admin/components/BeforeNavLinks";
-import Order from './collections/Orders';
-import { isUsingCloudStore } from './utilities/cloud';
-
+import Order from "./collections/Orders";
+import { isUsingCloudStore } from "./utilities/cloud";
 
 const adapter = createS3Adapter({
   config: {
@@ -59,21 +58,17 @@ export default buildConfig({
     user: Users.slug,
     css: path.resolve(__dirname, "admin", "styles.scss"),
   },
-  collections: [
-    Categories,
-    Posts,
-    Tags,
-    Users,
-    Media,
-    Order,
-  ],
+  collections: [Categories, Posts, Tags, Users, Media, Order],
   csrf: [
     // whitelist of domains to allow cookie auth from
     process.env.PAYLOAD_PUBLIC_SERVER_URL,
   ],
   typescript: {
     // outputFile: path.resolve(__dirname, "payload-types.ts"),
-    outputFile: path.resolve(__dirname, "../../../packages/types/src/lib/cms.ts"), // overridden by PAYLOAD_TS_OUTPUT_PATH env var
+    outputFile: path.resolve(
+      __dirname,
+      "../../../packages/types/src/lib/cms.ts"
+    ), // overridden by PAYLOAD_TS_OUTPUT_PATH env var
   },
   graphQL: {
     schemaOutputFile: path.resolve(
@@ -81,13 +76,15 @@ export default buildConfig({
       "../../../packages/schemas/lib/cms.graphql"
     ),
   },
-  plugins: isUsingCloudStore() ? [
-    cloudStorage({
-      collections: {
-        media: {
-          adapter: adapter,
-        }
-      },
-    }),
-  ]: [],
+  plugins: isUsingCloudStore()
+    ? [
+      cloudStorage({
+        collections: {
+          media: {
+            adapter: adapter,
+          },
+        },
+      }),
+    ]
+    : [],
 });

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -17,6 +17,8 @@ import MerchProducts from "./admin/views/MerchProducts";
 import { SCSEIcon, SCSELogo } from "./admin/graphics/Logos";
 import BeforeNavLinks from "./admin/components/BeforeNavLinks";
 import Order from './collections/Orders';
+import { isUsingCloudStore } from './utilities/cloud';
+
 
 const adapter = createS3Adapter({
   config: {
@@ -79,7 +81,7 @@ export default buildConfig({
       "../../../packages/schemas/lib/cms.graphql"
     ),
   },
-  plugins: [
+  plugins: isUsingCloudStore() ? [
     cloudStorage({
       collections: {
         media: {
@@ -87,5 +89,5 @@ export default buildConfig({
         }
       },
     }),
-  ],
+  ]: [],
 });

--- a/apps/cms/src/utilities/cloud.ts
+++ b/apps/cms/src/utilities/cloud.ts
@@ -1,0 +1,11 @@
+/**
+ * Determine if we are using cloud storage (AWS S3) by detecting environment vars.
+ *
+ * @returns true if using cloud storage, false otherwise.
+ */
+export function isUsingCloudStore(): boolean {
+  return (
+    process.env?.S3_ACCESS_KEY_ID != null &&
+    process.env.S3_ACCESS_KEY_ID.length !== 0
+  );
+}

--- a/packages/types/src/lib/cms.ts
+++ b/packages/types/src/lib/cms.ts
@@ -12,6 +12,7 @@ export interface Config {
     tags: Tag;
     users: User;
     media: Media;
+    orders: Order;
   };
   globals: {};
 }
@@ -86,4 +87,14 @@ export interface User {
   loginAttempts?: number;
   lockUntil?: string;
   password?: string;
+}
+export interface Order {
+  id: string;
+  paymentGateway: string;
+  status: '1' | '2' | '3';
+  customerEmail: string;
+  transactionID: string;
+  orderDateTime: string;
+  updatedAt: string;
+  createdAt: string;
 }

--- a/packages/types/src/lib/cms.ts
+++ b/packages/types/src/lib/cms.ts
@@ -101,7 +101,7 @@ export interface User {
 export interface Order {
   id: string;
   paymentGateway: string;
-  status: '1' | '2' | '3';
+  status: 'pending' | 'paid' | 'delivered';
   customerEmail: string;
   transactionID: string;
   orderDateTime: string;

--- a/packages/types/src/lib/cms.ts
+++ b/packages/types/src/lib/cms.ts
@@ -5,6 +5,16 @@
  * and re-run `payload generate:types` to regenerate this file.
  */
 
+export type OrderItem = {
+  image?: string | Media;
+  quantity: number;
+  size: string;
+  price: number;
+  name: string;
+  colorway: string;
+  id?: string;
+}[];
+
 export interface Config {
   collections: {
     categories: Category;
@@ -95,6 +105,7 @@ export interface Order {
   customerEmail: string;
   transactionID: string;
   orderDateTime: string;
+  orderItems?: OrderItem;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
# Motivation
See [Card](https://github.com/orgs/ntuscse/projects/3/views/1?pane=issue&itemId=49452810).

# Contents
Add `Orders` collection modeled after [original DyanmoDB schema](https://github.com/ntuscse/website/blob/92ebc44840e00e69390784ef327d6257ad925fa3/apps/merch/src/db/orders.ts#L15-L34):
- `OrderItems` are nested within Orders and unlike the original schema do not have their own ids.
- [REST API generated by Payload (Postman)](https://www.postman.com/np-web-folo-team/workspace/ntu-it-scse/collection/8002210-22aef117-c3e9-4c04-9f4c-a5f320276bcb?action=share&creator=8002210&active-environment=8002210-05309c0b-bf30-4af4-89d3-902e502a3eb4)

Infrastructure:
- CMS docker-compose: mount declared volume instead of bind mounting potentially non-existent directory.

Quality of Life:
- Disable S3 cloud storage support & revert to local storage if `S3_ACCESS_KEY_ID` environment variable is not set to improve local development experience.
