### PR TITLE
feat(cms): Add Product API to CMS

### DIFF
--- a/apps/cms/src/collections/Products.ts
+++ b/apps/cms/src/collections/Products.ts
@@ -1,0 +1,126 @@
+import { CollectionConfig } from "payload/types";
+
+/** Products collection stores merch products offerings. */
+export const Products: CollectionConfig = {
+  slug: "products",
+  admin: {
+    description: "Merchandise products offerings",
+  },
+  fields: [
+    // by default, payload generates an 'id' field each order automatically
+    {
+      name: "name",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "colors",
+      type: "select",
+      hasMany: true,
+      options: [
+        {
+          label: "Black",
+          value: "black",
+        },
+        {
+          label: "White",
+          value: "white",
+        },
+        {
+          label: "Blue",
+          value: "blue",
+        },
+      ],
+    },
+    {
+      name: "sizes",
+      type: "select",
+      hasMany: true,
+      options: [
+        {
+          label: "Small",
+          value: "s",
+        },
+        {
+          label: "Medium",
+          value: "m",
+        },
+        {
+          label: "Large",
+          value: "l",
+        },
+        {
+          label: "Extra Large",
+          value: "xl",
+        },
+      ],
+    },
+    {
+      name: "images",
+      type: "array",
+      fields: [
+        {
+          name: "url",
+          type: "text",
+          required: true,
+        },
+      ],
+    },
+    {
+      name: "is_available",
+      label: "Is Available",
+      type: "checkbox",
+    },
+    {
+      name: "price",
+      type: "number",
+      required: true,
+      admin: {
+        step: 0.01,
+      },
+      min: 0,
+    },
+    {
+      name: "category",
+      type: "select",
+      required: true,
+      options: [
+        {
+          label: "Shirt",
+          value: "shirt",
+        },
+        {
+          label: "Hat",
+          value: "hat",
+        },
+      ],
+    },
+    {
+      name: "size_chart",
+      type: "text",
+    },
+    {
+      name: "stock",
+      type: "array",
+      fields: [
+        {
+          name: "color",
+          type: "select",
+          options: ["black", "white", "blue"],
+          required: true,
+        },
+        {
+          name: "quantity",
+          type: "number",
+          admin: {
+            step: 1,
+          },
+          required: true,
+          min: 0,
+        },
+      ],
+    },
+  ],
+};
+
+export default Products;

--- a/apps/cms/src/collections/Products.ts
+++ b/apps/cms/src/collections/Products.ts
@@ -5,6 +5,7 @@ export const Products: CollectionConfig = {
   slug: "products",
   admin: {
     description: "Merchandise products offerings",
+    defaultColumns: ["name", "category", "price", "is_available"],
   },
   fields: [
     // by default, payload generates an 'id' field each order automatically
@@ -15,45 +16,14 @@ export const Products: CollectionConfig = {
     },
     {
       name: "colors",
-      type: "select",
+      type: "text",
+      required: true,
       hasMany: true,
-      options: [
-        {
-          label: "Black",
-          value: "black",
-        },
-        {
-          label: "White",
-          value: "white",
-        },
-        {
-          label: "Blue",
-          value: "blue",
-        },
-      ],
     },
     {
       name: "sizes",
-      type: "select",
+      type: "text",
       hasMany: true,
-      options: [
-        {
-          label: "Small",
-          value: "s",
-        },
-        {
-          label: "Medium",
-          value: "m",
-        },
-        {
-          label: "Large",
-          value: "l",
-        },
-        {
-          label: "Extra Large",
-          value: "xl",
-        },
-      ],
     },
     {
       name: "images",
@@ -82,21 +52,14 @@ export const Products: CollectionConfig = {
     },
     {
       name: "category",
-      type: "select",
+      type: "text",
       required: true,
-      options: [
-        {
-          label: "Shirt",
-          value: "shirt",
-        },
-        {
-          label: "Hat",
-          value: "hat",
-        },
-      ],
+      hasMany: true,
+      minRows: 1,
     },
     {
       name: "size_chart",
+      label: "Size Chart",
       type: "text",
     },
     {
@@ -105,8 +68,12 @@ export const Products: CollectionConfig = {
       fields: [
         {
           name: "color",
-          type: "select",
-          options: ["black", "white", "blue"],
+          type: "text",
+          required: true,
+        },
+        {
+          name: "size",
+          type: "text",
           required: true,
         },
         {

--- a/apps/cms/src/payload.config.ts
+++ b/apps/cms/src/payload.config.ts
@@ -19,9 +19,10 @@ import MerchProducts from "./admin/views/MerchProducts";
 import MerchPromotion from "./admin/views/MerchPromotion";
 import { SCSEIcon, SCSELogo } from "./admin/graphics/Logos";
 import BeforeNavLinks from "./admin/components/BeforeNavLinks";
-import Order from "./collections/Orders";
+import Orders from "./collections/Orders";
 import { isUsingCloudStore } from "./utilities/cloud";
 import { mongooseAdapter } from "@payloadcms/db-mongodb";
+import Products from "./collections/Products";
 
 const adapter = createS3Adapter({
   config: {
@@ -85,7 +86,7 @@ export default buildConfig({
       return config
     },
   },
-  collections: [Categories, Posts, Tags, Users, Media, Order],
+  collections: [Categories, Posts, Tags, Users, Media, Orders, Products],
   csrf: [
     // whitelist of domains to allow cookie auth from
     process.env.PAYLOAD_PUBLIC_SERVER_URL,
@@ -115,3 +116,5 @@ export default buildConfig({
       ]
     : [],
 });
+
+

--- a/apps/cms/src/types.ts
+++ b/apps/cms/src/types.ts
@@ -160,8 +160,8 @@ export interface Order {
 export interface Product {
   id: string;
   name: string;
-  colors?: ('black' | 'white' | 'blue')[] | null;
-  sizes?: ('s' | 'm' | 'l' | 'xl')[] | null;
+  colors: string[];
+  sizes?: string[] | null;
   images?:
     | {
         url: string;
@@ -170,11 +170,12 @@ export interface Product {
     | null;
   is_available?: boolean | null;
   price: number;
-  category: 'shirt' | 'hat';
+  category: string[];
   size_chart?: string | null;
   stock?:
     | {
-        color: 'black' | 'white' | 'blue';
+        color: string;
+        size: string;
         quantity: number;
         id?: string | null;
       }[]

--- a/apps/cms/src/types.ts
+++ b/apps/cms/src/types.ts
@@ -30,6 +30,7 @@ export interface Config {
     users: User;
     media: Media;
     orders: Order;
+    products: Product;
     'payload-preferences': PayloadPreference;
     'payload-migrations': PayloadMigration;
   };
@@ -149,6 +150,35 @@ export interface Order {
   paymentMethod: string;
   customerEmail: string;
   status: 'pending' | 'paid' | 'delivered';
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "products".
+ */
+export interface Product {
+  id: string;
+  name: string;
+  colors?: ('black' | 'white' | 'blue')[] | null;
+  sizes?: ('s' | 'm' | 'l' | 'xl')[] | null;
+  images?:
+    | {
+        url: string;
+        id?: string | null;
+      }[]
+    | null;
+  is_available?: boolean | null;
+  price: number;
+  category: 'shirt' | 'hat';
+  size_chart?: string | null;
+  stock?:
+    | {
+        color: 'black' | 'white' | 'blue';
+        quantity: number;
+        id?: string | null;
+      }[]
+    | null;
   updatedAt: string;
   createdAt: string;
 }


### PR DESCRIPTION
# Motivation
See [card](https://github.com/orgs/ntuscse/projects/3/views/1?pane=issue&itemId=50879030)



# Contents
> :warning: Needs #158

Implements Product API in CMS with the following product schema:
- Some schema deviations from the original Product schema in `package/types/lib/merch.ts` due to Payload limitations.

```json
{
  "id": "665c24f355ede133318452da",
  "name": "Product",
  "colors": [
    "black",
    "blue"
  ],
  "sizes": [
    "s",
    "xl"
  ],
  "images": [
    {
      "url": "https://github.com/ntuscse/website/pull/158",
      "id": "665c24c7a1786092419c4a90"
    },
    {
      "url": "https://github.com/ntuscse/website/pull/158",
      "id": "665c24cda1786092419c4a91"
    }
  ],
  "price": 0.2,
  "category": "hat",
  "size_chart": "https://github.com/ntuscse/website/pull/158",
  "stock": [
    {
      "color": "white",
      "quantity": 5,
      "id": "665c24e1a1786092419c4a92"
    }
  ],
  "createdAt": "2024-06-02T07:53:23.679Z",
  "updatedAt": "2024-06-02T07:53:23.679Z"
}
```

Demo: Download & import [Postman API collection](https://api.postman.com/collections/8002210-5c13d3cd-d315-4cd1-8e4e-25b119f282a8?access_key=PMAT-01HZBZZ1TRQZ2ECY26JW3W6PAX)
